### PR TITLE
v2.1 - Add guard to prevent more than 5000 characters

### DIFF
--- a/TranslationApp/ViewModels/MainWindow.xaml.cs
+++ b/TranslationApp/ViewModels/MainWindow.xaml.cs
@@ -13,6 +13,12 @@ namespace TranslationApp
 
         private void Translate(object sender, RoutedEventArgs e)
         {
+            if (textToTranslate.Text.Length >= 5000)
+            {
+                translatedText.Text = "Google API does not support translation above 5000 characters.";
+                return;
+            }
+
             // retrieve API Key from Environment variable set up
             // TODO v0.5 - set up the key in a config file
             var client = TranslationClient.CreateFromApiKey(Environment.GetEnvironmentVariable("api_key"));


### PR DESCRIPTION
Google Translation API has a limit of 5000 characters, this prevents that from ever causing our application to throw an exception.