### PR TITLE
Fix Default Language Bug

### DIFF
--- a/TranslationApp/ViewModels/MainWindow.xaml.cs
+++ b/TranslationApp/ViewModels/MainWindow.xaml.cs
@@ -37,6 +37,8 @@ namespace TranslationApp
                     box2.Items.Add(language.Name);
                 }
             }
+            // default language to english
+            box2.SelectedItem = "English";
         }
 
         // translate provided text

--- a/TranslationApp/Views/MainWindow.xaml
+++ b/TranslationApp/Views/MainWindow.xaml
@@ -139,7 +139,6 @@
         <ComboBox 
             Name="box2"
             Margin="20,20,150,20" 
-            Text="English" 
             HorizontalAlignment="Stretch"
             FontFamily="/Fonts/#Roboto"
             IsEditable="True"


### PR DESCRIPTION
There was a bug with default language that causes the application to throw an exception. The default language should be set from the backend, not the UI. This should fix the mentioned problem.