### PR TITLE
Fix Bug Related to Language Dropbox

### DIFF
--- a/TranslationApp/App.xaml.cs
+++ b/TranslationApp/App.xaml.cs
@@ -10,13 +10,29 @@ namespace TranslationApp
     /// </summary>
     public partial class App : Application
     {
-        private static Dictionary<string, string> m_languagesKeys = new Dictionary<string, string>();
         private static TranslationClient m_client = TranslationClient.CreateFromApiKey(Environment.GetEnvironmentVariable("api_key"));
-        public static Dictionary<string, string> LanguageKeys { get => m_languagesKeys; set => m_languagesKeys = value; }
         public static TranslationClient Client { get => m_client; }
+
+        private static Dictionary<string, string> m_languagesKeys = GetLanguageLists();
+        public static Dictionary<string, string> LanguageKeys { get => m_languagesKeys; set => m_languagesKeys = value; }
+        
         private void Application_Navigated(object sender, System.Windows.Navigation.NavigationEventArgs e)
         {
+            
+        }
 
+        // get language lists
+        public static Dictionary<string, string> GetLanguageLists()
+        {
+            var list = new Dictionary<string, string>();
+            foreach (Language language in Client.ListLanguages("en"))
+            {
+                if (!list.ContainsKey(language.Name))
+                {
+                    list.Add(language.Name, language.Code);
+                }
+            }
+            return list;
         }
     }
 }

--- a/TranslationApp/ViewModels/MultiLanguagesPage.xaml.cs
+++ b/TranslationApp/ViewModels/MultiLanguagesPage.xaml.cs
@@ -29,19 +29,14 @@ namespace TranslationApp
             multiLangSelect.Items.Clear();
             // get all supported language by Google
             // "en" - defines the language of all the names of the languages
-            IList<Language> supportedLanguages = App.Client.ListLanguages("en");
 
-            foreach (Language language in supportedLanguages)
+            foreach (string language in App.LanguageKeys.Keys)
             {
-                if (!App.LanguageKeys.ContainsKey(language.Name))
-                {
-                    App.LanguageKeys.Add(language.Name, language.Code);
-                }
                 CheckBox chkbox = new CheckBox();
-                chkbox.Content = language.Name;
+                chkbox.Content = language;
                 chkbox.Checked += new RoutedEventHandler(SelectionChecked);
                 chkbox.Unchecked += new RoutedEventHandler(SelectionChecked);
-                multiLangSelect.Items.Add(chkbox);              
+                multiLangSelect.Items.Add(chkbox);
             }
             // default language to english
             multiLangSelect.SelectedItem = "English";

--- a/TranslationApp/ViewModels/SingleLanguagePage.xaml.cs
+++ b/TranslationApp/ViewModels/SingleLanguagePage.xaml.cs
@@ -30,14 +30,9 @@ namespace TranslationApp
             box2.Items.Clear();
             // get all supported language by Google
             // "en" - defines the language of all the names of the languages
-            IList<Language> supportedLanguages = App.Client.ListLanguages("en");
-            foreach (Language language in supportedLanguages)
+            foreach (string language in App.LanguageKeys.Keys)
             {
-                if (!App.LanguageKeys.ContainsKey(language.Name))
-                {
-                    App.LanguageKeys.Add(language.Name, language.Code);
-                    box2.Items.Add(language.Name);
-                }
+                box2.Items.Add(language);
             }
             // default language to english
             box2.SelectedItem = "English";


### PR DESCRIPTION
Found a bug that causes the first page language box to clear out all elements after navigating to the second page.
Turns out the language keys are still being retrieved twice.

This fix should only get the supported language once and has the languages propagate throughout the application.